### PR TITLE
Adding ISBN=0 for books that do not have ISBN and have similarity >=0.95

### DIFF
--- a/server.js
+++ b/server.js
@@ -390,7 +390,7 @@ app.get('/search', async (req, res) => {
           publishedYear: publishedYear,
           description: book.description || undefined,
           cover: book.cover || undefined,
-          isbn: book.identifiers?.isbn || undefined,
+          isbn: book.identifiers?.isbn || (book.similarity >= 0.95 ? '0' : undefined), // '0' indicates missing ISBN with high similarity
           asin: book.identifiers?.asin || undefined,
           genres: book.genres || undefined,
           tags: book.tags || undefined,


### PR DESCRIPTION
Combined with the "Skip matching books that already have an ISBN" option in ABS, it will make sure that books aren't matched over and over again.